### PR TITLE
Comment out  nextjs.yml

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,103 +1,103 @@
-# Sample workflow for building and deploying a Next.js site to GitHub Pages
-#
-# To get started with Next.js see: https://nextjs.org/docs/getting-started
-#
-name: Deploy Next.js site to Pages
+# # Sample workflow for building and deploying a Next.js site to GitHub Pages
+# #
+# # To get started with Next.js see: https://nextjs.org/docs/getting-started
+# #
+# name: Deploy Next.js site to Pages
 
-on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["master"]
+# on:
+#   # Runs on pushes targeting the default branch
+#   push:
+#     branches: ["master"]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+#   # Allows you to run this workflow manually from the Actions tab
+#   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# permissions:
+#   contents: read
+#   pages: write
+#   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+# # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# concurrency:
+#   group: "pages"
+#   cancel-in-progress: false
 
-jobs:
-  # Build job
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/pnpm-lock.yaml" ]; then
-            echo "manager=pnpm" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=pnpm" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
-      - name: Setup pnpm
-        if: steps.detect-package-manager.outputs.manager == 'pnpm'
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-
-      - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-      - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./out
+# jobs:
+#   # Build job
+#   build:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v4
+#       - name: Detect package manager
+#         id: detect-package-manager
+#         run: |
+#           if [ -f "${{ github.workspace }}/pnpm-lock.yaml" ]; then
+#             echo "manager=pnpm" >> $GITHUB_OUTPUT
+#             echo "command=install" >> $GITHUB_OUTPUT
+#             echo "runner=pnpm" >> $GITHUB_OUTPUT
+#             exit 0
+#           elif [ -f "${{ github.workspace }}/yarn.lock" ]; then
+#             echo "manager=yarn" >> $GITHUB_OUTPUT
+#             echo "command=install" >> $GITHUB_OUTPUT
+#             echo "runner=yarn" >> $GITHUB_OUTPUT
+#             exit 0
+#           elif [ -f "${{ github.workspace }}/package.json" ]; then
+#             echo "manager=npm" >> $GITHUB_OUTPUT
+#             echo "command=ci" >> $GITHUB_OUTPUT
+#             echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+#             exit 0
+#           else
+#             echo "Unable to determine package manager"
+#             exit 1
+#           fi
+#       - name: Setup pnpm
+#         if: steps.detect-package-manager.outputs.manager == 'pnpm'
+#         uses: pnpm/action-setup@v3
+#         with:
+#           version: 8
+#       - name: Setup Node
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: "20"
+#           cache: ${{ steps.detect-package-manager.outputs.manager }}
+#       - name: Setup Pages
+#         uses: actions/configure-pages@v5
+#         with:
+#           # Automatically inject basePath in your Next.js configuration file and disable
+#           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+#           #
+#           # You may remove this line if you want to manage the configuration yourself.
+#           static_site_generator: next
+#       - name: Restore cache
+#         uses: actions/cache@v4
+#         with:
+#           path: |
+#             .next/cache
+#           # Generate a new cache whenever packages or source files change.
+#           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+#           # If source files changed but packages didn't, rebuild from a prior cache.
+#           restore-keys: |
+#             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-
+#       - name: Install dependencies
+#         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+#       - name: Build with Next.js
+#         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+#       - name: Upload artifact
+#         uses: actions/upload-pages-artifact@v3
+#         with:
+#           path: ./out
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+#   # Deployment job
+#   deploy:
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment.outputs.page_url }}
+#     runs-on: ubuntu-latest
+#     needs: build
+#     steps:
+#       - name: Deploy to GitHub Pages
+#         id: deployment
+#         uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request comments out the entire workflow configuration in `.github/workflows/nextjs.yml`, effectively disabling the GitHub Actions workflow for building and deploying a Next.js site to GitHub Pages.

Key changes:

* **Workflow Disabling**:
  - All sections of the workflow, including triggers (`on`), permissions, concurrency settings, build job, and deployment job, have been commented out. This prevents the workflow from running while preserving the original configuration for potential future use.

## Summary by Sourcery

Chores:
- Disable the Next.js build and deployment workflow by commenting out all lines in .github/workflows/nextjs.yml